### PR TITLE
[IMP] change priority - analytic default settings to prevail

### DIFF
--- a/account_analytic_default_product_category/models/account_analytic_default.py
+++ b/account_analytic_default_product_category/models/account_analytic_default.py
@@ -22,12 +22,13 @@ class account_analytic_default(osv.osv):
     _inherit = "account.analytic.default"
 
     def account_get(self, cr, uid, product_id=None, partner_id=None, user_id=None, date=None, context=None):
-        categ = self.pool.get('product.product').browse(cr, uid, product_id, context=context).categ_id
-        if categ.analytic_id:
-            return categ
-        else:
-            res = super(account_analytic_default, self).account_get(cr, uid, product_id, partner_id, user_id, date, context=context)
-            return res
+        res = super(account_analytic_default, self).account_get(cr, uid, product_id, partner_id, user_id, date, context=context)
+        if not res:
+            categ = self.pool.get('product.product').browse(cr, uid, product_id, context=context).categ_id
+            if categ.analytic_id:
+                res = categ
+        return res
+
 
 account_analytic_default()
 


### PR DESCRIPTION
As mentioned, we would like to make the standard analytic default settings to be stronger than the analytic account set in product category.   This is to make the module more generic (if there is analytic default entry for a specific product, we would like to use that instead of proposing analytic account from product category).