### PR TITLE
[FIX] Price calculation in cart

### DIFF
--- a/sale_category_discount/__manifest__.py
+++ b/sale_category_discount/__manifest__.py
@@ -3,7 +3,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 {
     'name': 'Discount by Product Category',
-    'version': '10.0.2.0.0',
+    'version': '10.0.2.0.1',
     'license': 'LGPL-3',
     'category':'Sales',
     'description': """

--- a/sale_category_discount/models/sale_order_line.py
+++ b/sale_category_discount/models/sale_order_line.py
@@ -80,8 +80,11 @@ class SaleOrderLine(models.Model):
                     fiscal_position=l.env.context.get(
                         'fiscal_position')
                 )
+                customer_currency = l.order_id.company_id.currency_id
+                product_price = customer_currency.compute(
+                    product.price, l.order_id.pricelist_id.currency_id)
                 l.price_unit = self.env[
-                    'account.tax']._fix_tax_included_price(product.price,
+                    'account.tax']._fix_tax_included_price(product_price,
                                                            product.taxes_id,
                                                            l.tax_id)
 

--- a/sale_category_discount/models/sale_order_line.py
+++ b/sale_category_discount/models/sale_order_line.py
@@ -80,19 +80,8 @@ class SaleOrderLine(models.Model):
                     fiscal_position=l.env.context.get(
                         'fiscal_position')
                 )
-                # Consider discount policy and set correct value for
-                # price_unit.
-                if l.order_id.pricelist_id.discount_policy == \
-                        "with_discount":
-                    product_price = l._get_display_price(product)
-                else:
-                    product_price = \
-                        l.order_id.pricelist_id.get_product_price(
-                        l.product_id, l.product_uom_qty or 1.0,
-                        l.order_id.partner_id)
-
                 l.price_unit = self.env[
-                    'account.tax']._fix_tax_included_price(product_price,
+                    'account.tax']._fix_tax_included_price(product.price,
                                                            product.taxes_id,
                                                            l.tax_id)
 


### PR DESCRIPTION
When the discount_policy of pricelist is "with_discount", `_get_display_price ` will return the list price of the product instead of the discounted price. Hence, `get_product_price` is used to calculate the product price under the pricelist when the discount policy is not "with_discount".

@yostashiro Please review the PR.