### PR TITLE
[FIX] Cancel a previous year sales record

### DIFF
--- a/sale_pricelist_auto_update/__manifest__.py
+++ b/sale_pricelist_auto_update/__manifest__.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Quartile Limited
+# Copyright 2017-2018 Quartile Limited
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 {
     'name': 'Auto Update Customer Pricelist',
     'summary': '',
-    'version': '10.0.1.0.1',
+    'version': '10.0.1.0.2',
     'license': 'LGPL-3',
     'category':'Sales',
     'description': """
@@ -12,7 +12,7 @@
 amount.
     """,
     'author' : 'Quartile Limited',
-    'website': 'https://www.odoo-asia.com',
+    'website': 'https://www.quartile.co',
     'depends': [
         'delivery',
         'date_range',

--- a/sale_pricelist_auto_update/models/res_partner.py
+++ b/sale_pricelist_auto_update/models/res_partner.py
@@ -42,8 +42,8 @@ class ResPartner(models.Model):
             lambda x: (x.start_date <= today and x.end_date >= today) or
                       (x.start_date <= last_year and x.end_date >= last_year)
         )
-        amount = hist_recs.sorted(
-            key=lambda r: r.amt_total)[-1].amt_total
+        amount = hist_recs.sorted(key=lambda r: r.amt_total)[-1].amt_total \
+            if hist_recs else 0
         group = self.property_product_pricelist.pricelist_group_id
         if group and not self.fix_pricelist:
             new_pricelist = self.env['product.pricelist'].search(

--- a/sale_pricelist_auto_update/models/res_partner.py
+++ b/sale_pricelist_auto_update/models/res_partner.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Quartile Limited
+# Copyright 2017-2018 Quartile Limited
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from dateutil.relativedelta import relativedelta


### PR DESCRIPTION
@yostashiro This PR will handle the following situation:

Background:
1. The customer has only 1 sales order in 2016.
2. The user tries to cancel that sales order.

Expected output:
1. The pricelist should be reset to default (if it is not).
2. A yearly sales record of 2016 should be created.

Current behavior:
1. A yearly sales record of 2016 is created.
2. When the following line attempts to get the yearly sales record of either last year or this year, `hist_recs` returns empty therefore the `[-1]` will give error. 
```
hist_recs = self.yearly_sales_history_ids.filtered(
	lambda x: (x.start_date <= today and x.end_date >= today) or
			  (x.start_date <= last_year and x.end_date >= last_year)
)
```

Fix:
If there is no yearly sales record, the amount should be set to 0.