### PR TITLE
[FIX] Sale Quotation Doamin

### DIFF
--- a/sale_quotation_auto_confirm/models/sale_order.py
+++ b/sale_quotation_auto_confirm/models/sale_order.py
@@ -23,6 +23,7 @@ class SaleOrder(models.Model):
                 ('team_id', '=', sale_team.id),
                 '|',
                 ('requested_date', '<=', threshold_date),
+                '&',
                 ('requested_date', '=', False),
                 ('commitment_date', '<=', threshold_date),
             ])


### PR DESCRIPTION
This PR will fix the issue in the domain search of the quotations.

Settings:
Direct Sales
- Days to Add in Threshold Date: 7
- Auto Confirm Sales Order by Scheduled Action: True

Test Cases:
1. Request Date <= Threshold Date, Commitment Date >  Threshold Date
    Expectation: Confirm Quotation
    Result: Pass
2. Request Date is Empty, Commitment Date >  Threshold Date
    Expectation: Remain Quotation
    Result: Pass
3. Request Date > Threshold Date, Commitment Date <=  Threshold Date
    Expectation: Remain Quotation
    Result: Pass
4. Request Date <= Threshold Date, Commitment Date <=  Threshold Date
    Expectation: Confirm Quotation
    Result: Pass
5. Request Date is Empty, Commitment Date <=  Threshold Date
    Expectation: Remain Quotation
    Result: Pass

![image](https://user-images.githubusercontent.com/27185427/40304512-9a9fdc14-5d29-11e8-8877-23c8ec9072d2.png)


