### PR TITLE
[ADD] mrp_change_source_location

### DIFF
--- a/mrp_change_source_location/__init__.py
+++ b/mrp_change_source_location/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import models
+from . import wizard

--- a/mrp_change_source_location/__manifest__.py
+++ b/mrp_change_source_location/__manifest__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    "name": "Manufacturing Order Change Source Locations",
+    "summary": "",
+    "description": """
+""",
+    "version": "10.0.1.0.0",
+    "category": "Manufacturing",
+    "website": "https://www.quartile.co",
+    "author": "Quartile Limited",
+    "license": "AGPL-3",
+    "installable": True,
+    "depends": [
+        "mrp",
+    ],
+    "data": [
+        'wizard/change_source_location_wizard_views.xml',
+        'views/mrp_production_views.xml',
+    ],
+}

--- a/mrp_change_source_location/models/__init__.py
+++ b/mrp_change_source_location/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import mrp_production

--- a/mrp_change_source_location/models/mrp_production.py
+++ b/mrp_change_source_location/models/mrp_production.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models, fields, api
+
+
+class MrpProduction(models.Model):
+    _inherit = "mrp.production"
+
+    def change_source_location(self):
+        form_id = self.env.ref(
+            'mrp_change_source_location.change_source_location_wizard_form')
+        return {
+            'type': 'ir.actions.act_window',
+            'name': 'Change Source Location',
+            'res_model': 'change.source.location.wizard',
+            'view_type': 'form',
+            'view_mode': 'form',
+            'view_id': form_id.id,
+            'context': {},
+            'target': 'new',
+        }

--- a/mrp_change_source_location/views/mrp_production_views.xml
+++ b/mrp_change_source_location/views/mrp_production_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="mrp_production_form_view" model="ir.ui.view">
+        <field name="name">mrp.production.form</field>
+        <field name="model">mrp.production</field>
+        <field name="inherit_id" ref="mrp.mrp_production_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='action_cancel']" position="before">
+                <button string="Change Source Location"
+                        states="confirmed" type="object"
+                        name="change_source_location"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/mrp_change_source_location/wizard/__init__.py
+++ b/mrp_change_source_location/wizard/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import change_source_location_wizard

--- a/mrp_change_source_location/wizard/change_source_location_wizard.py
+++ b/mrp_change_source_location/wizard/change_source_location_wizard.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models, fields, api
+
+
+class ChangeSourceLocationWizard(models.TransientModel):
+    _name = "change.source.location.wizard"
+
+    source_location_id = fields.Many2one(
+        comodel_name='stock.location',
+        string='Source Location',
+    )
+
+    def action_change_source_location(self):
+        manufacturing_orders = self.env['mrp.production'].browse(
+            self._context.get('active_ids', []))
+        for order in manufacturing_orders:
+            if order.location_src_id != self.source_location_id:
+                order.do_unreserve()
+                order.location_src_id = self.source_location_id
+                for move in order.move_raw_ids:
+                    move.location_id = self.source_location_id
+        return

--- a/mrp_change_source_location/wizard/change_source_location_wizard_views.xml
+++ b/mrp_change_source_location/wizard/change_source_location_wizard_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="change_source_location_wizard_form" model="ir.ui.view">
+        <field name="name">change.source.location.wizard.form</field>
+        <field name="model">change.source.location.wizard</field>
+        <field name="arch" type="xml">
+        <form string="Change Source Location">
+            <group>
+                <field name="source_location_id"
+                       domain="[('usage', '=', 'internal')]"/>
+            </group>
+            <footer>
+                <button name="action_change_source_location" string="Change"
+                        type="object" class="oe_highlight"/>
+                or
+                <button string="Cancel" class="oe_link" special="cancel"/>
+            </footer>
+        </form>
+       </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
- Allow users to change the `Raw Materials Location` of `Confirmed` Manufacturing Orders
- When the `Raw Materials Location` is being changed, related `Consumed Materials` stock moves of the order  (`move_raw_ids`) will be unreserved and the `Source Location` of the stock moves will be updated.