### PR TITLE
[IMP] make price_unit_manual a non-computed field

### DIFF
--- a/sale_category_discount/__manifest__.py
+++ b/sale_category_discount/__manifest__.py
@@ -3,11 +3,11 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 {
     'name': 'Discount by Product Category',
-    'version': '10.0.2.1.0',
+    'version': '10.0.2.2.0',
     'license': 'LGPL-3',
     'category':'Sales',
     'description': """
-- Adds function to apply discount based on aggregated qty per category in a \
+- Adds function to apply discount based on aggregated qty per category in a
 sales order.
     """,
     'author' : 'Quartile Limited',


### PR DESCRIPTION
This commit changes price_unit_manual from a stored computed field to
a non-computed field.

This is due to the behavior described in https://github.com/odoo/odoo/issues/14279 - when "Send by Email" is pressed in SO, Odoo re-calculates computed fields for report generation, and price_unit_manual would always result to be zero, which is different to the DB record value, and the price presentation becomes incorrect in generated report. This commit is to work around this problematic behavior.