### PR TITLE
[IMP] make price_unit_manual a non-computed field

### DIFF
--- a/sale_category_discount/__manifest__.py
+++ b/sale_category_discount/__manifest__.py
@@ -3,7 +3,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 {
     'name': 'Discount by Product Category',
-    'version': '10.0.2.1.0',
+    'version': '10.0.2.2.0',
     'license': 'LGPL-3',
     'category':'Sales',
     'description': """

--- a/sale_category_discount/models/sale_order_line.py
+++ b/sale_category_discount/models/sale_order_line.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Quartile Limited
+# Copyright 2017-2018 Quartile Limited
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from odoo import models, fields, api
@@ -30,15 +30,16 @@ class SaleOrderLine(models.Model):
         digits=dp.get_precision('Product Price'),
         default=0.0,
         compute='_recompute_price_unit',
-        inverse='_inverse_price_unit',
         store=True,
     )
+    # this field has been changed to non-computed field due to the issue
+    # described in https://github.com/odoo/odoo/issues/14279
+    # e.g. printed quotation from "Send by Email" showed the wrong amount
+    # as price_unit_manual was regarded as zero during price recomputation
     price_unit_manual = fields.Float(
         'Unit Price (Manual)',
         digits=dp.get_precision('Product Price'),
         default=0.0,
-        compute='_update_price_unit_manual',
-        store=True,
     )
 
 
@@ -50,13 +51,22 @@ class SaleOrderLine(models.Model):
             return super(SaleOrderLine, self).product_uom_change()
 
     @api.multi
-    @api.depends('fixed_price')
-    def _update_price_unit_manual(self):
-        for l in self:
-            if l.fixed_price:
-                l.price_unit_manual = l.price_unit
-            else:
-                l.price_unit_manual = 0.0
+    def write(self, vals):
+        if vals.get('fixed_price'):
+            vals['price_unit_manual'] = vals['price_unit'] \
+                if 'price_unit' in vals else self.price_unit
+        elif 'fixed_price' in vals and not vals['fixed_price']:
+            vals['price_unit_manual'] = 0.0
+        elif self.fixed_price:
+            vals['price_unit_manual'] = vals['price_unit'] \
+                if 'price_unit' in vals else self.price_unit
+        return super(SaleOrderLine, self).write(vals)
+
+    @api.model
+    def create(self, vals):
+        if vals.get('fixed_price'):
+            vals['price_unit_manual'] = vals.get('price_unit')
+        return super(SaleOrderLine, self).create(vals)
 
     @api.multi
     @api.depends('price_categ_qty')
@@ -109,11 +119,6 @@ class SaleOrderLine(models.Model):
             else:
                 line.price_categ_qty = line_dict[line.id]
 
-    def _inverse_price_unit(self):
-        for l in self:
-            if l.fixed_price:
-                l.price_unit_manual = l.price_unit
-
     @api.multi
     @api.depends('product_id', 'order_id.pricelist_id')
     def _get_price_categ_id(self):
@@ -131,3 +136,4 @@ class SaleOrderLine(models.Model):
                         categ = False
                     else:
                         categ = categ.parent_id
+


### PR DESCRIPTION
This commit changes price_unit_manual from a stored computed field to a non-computed field.

This is due to the behavior described in https://github.com/odoo/odoo/issues/14279 - when "Send by Email" is pressed in SO, Odoo re-calculates computed fields for report generation, and price_unit_manual would always result to be zero, which is different to the DB record value, and the price presentation becomes incorrect in generated report. This commit is to work around this problematic behavior.