### PR TITLE
[ADD] sale_order_line_mrp_remarks

### DIFF
--- a/sale_order_line_mrp_remarks/__init__.py
+++ b/sale_order_line_mrp_remarks/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/sale_order_line_mrp_remarks/__manifest__.py
+++ b/sale_order_line_mrp_remarks/__manifest__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Quartile Limited
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+{
+    "name": "Remarks for Manufacturing Order",
+    "summary": "",
+    "description": """
+- Adds remark field in sales order line.
+- Pass the remark field to corresponding manufacturing orders.
+""",
+    "version": "10.0.1.0.0",
+    "category": "Manufacturing",
+    "website": "https://www.quartile.co",
+    "author": "Quartile Limited",
+    "license": "LGPL-3",
+    "installable": True,
+    "depends": [
+        "sale",
+        "mrp",
+    ],
+    "data": [
+        "views/sale_order_views.xml",
+        "views/mrp_production_views.xml",
+    ],
+}

--- a/sale_order_line_mrp_remarks/models/__init__.py
+++ b/sale_order_line_mrp_remarks/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+from . import mrp_production
+from . import sale_order
+from . import sale_order_line

--- a/sale_order_line_mrp_remarks/models/mrp_production.py
+++ b/sale_order_line_mrp_remarks/models/mrp_production.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Quartile Limited
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models, api
+
+
+class MrpProduction(models.Model):
+    _inherit = 'mrp.production'
+
+    remarks = fields.Char(
+        string="Remarks",
+    )

--- a/sale_order_line_mrp_remarks/models/sale_order.py
+++ b/sale_order_line_mrp_remarks/models/sale_order.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Quartile Limited
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models, api
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    @api.multi
+    def action_confirm(self):
+        res = super(SaleOrder, self).action_confirm()
+        for order in self:
+            manufacturing_orders = order.production_ids
+            # Sort the orders according to the ids, therefore the root order
+            # will be come back the leaf orders
+            for manufacturing_order in sorted(manufacturing_orders,
+                                              key=lambda x: x.id):
+                order_line = order.order_line.filtered(
+                    lambda t: t.product_id.product_tmpl_id ==
+                              manufacturing_order.product_id.product_tmpl_id)
+                # Set remarks to the root order
+                if order_line:
+                    manufacturing_order.remarks = order_line[0].remarks
+                # Find the related procurement orders to pass the remarks
+                # field to one level below of the manufacturing order
+                related_procurement_orders = self.env[
+                    'procurement.order'].search([
+                    ('origin', 'like', '%%%s%%' % manufacturing_order.name)
+                ])
+                for procurement_order in related_procurement_orders:
+                    # Set remarks to the leaf order
+                    if procurement_order.production_id:
+                        procurement_order.production_id.remarks = \
+                            manufacturing_order.remarks
+        return res

--- a/sale_order_line_mrp_remarks/models/sale_order_line.py
+++ b/sale_order_line_mrp_remarks/models/sale_order_line.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Quartile Limited
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models, api
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    remarks = fields.Char(
+        readonly=True,
+        copy=False,
+        states={'draft': [('readonly', False)], 'sent': [('readonly', False)]},
+        string="Remarks",
+    )

--- a/sale_order_line_mrp_remarks/views/mrp_production_views.xml
+++ b/sale_order_line_mrp_remarks/views/mrp_production_views.xml
@@ -6,7 +6,7 @@
         <field name="model">mrp.production</field>
         <field name="inherit_id" ref="mrp.mrp_production_form_view"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='origin']" position="after">
+            <xpath expr="//field[@name='product_id']" position="after">
                 <field name="remarks"/>
             </xpath>
         </field>

--- a/sale_order_line_mrp_remarks/views/mrp_production_views.xml
+++ b/sale_order_line_mrp_remarks/views/mrp_production_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="mrp_production_form_view" model="ir.ui.view">
+        <field name="name">mrp.production.form</field>
+        <field name="model">mrp.production</field>
+        <field name="inherit_id" ref="mrp.mrp_production_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='origin']" position="after">
+                <field name="remarks"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/sale_order_line_mrp_remarks/views/sale_order_views.xml
+++ b/sale_order_line_mrp_remarks/views/sale_order_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_order_form" model="ir.ui.view">
+        <field name="name">sale.order.form</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']/tree/field[@name='name']"
+                   position="after">
+                <field name="remarks"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
**Adjustments**
- Add `remarks` to `sale.order.line` and `mrp.production`
- Pass the `remarks` fields from `sale.order.line` to related manufacturing orders upon confirmation of the sales order.

**Design Restrictions**
- All the procurement orders are in the same procurement group, i.e. cannot use the group to identify the orders when there are two products
- All the manufacturing orders are linked to the sales order but not specifically to sales order line.

**Logic Explanation**
- For the procurement order that is linked to sales order line, the parent manufacturing order could be traced by checking `move_orig_ids`
- For the child manufactoring orders, check the `move_orig_ids` of every `move_raw_ids` in parent manufacturing order.