### PR TITLE
Fix product procurement plan

### DIFF
--- a/product_procurement_plan/__init__.py
+++ b/product_procurement_plan/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Rooms For (Hong Kong) Limited T/A OSCG
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from . import models
 from . import wizard

--- a/product_procurement_plan/__manifest__.py
+++ b/product_procurement_plan/__manifest__.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Rooms For (Hong Kong) Limited T/A OSCG
+# Copyright 2017-2018 Quartile Limited
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 {
     'name': 'Product Procurement Planning',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Product',
     'summary': '',
     'description': """
@@ -13,7 +13,7 @@ Main Features
 2. Adds a menu item to open a wizard to run updates on procurement related fields in product.
 3. Adds a menu item to open a product tree view tailored to show procurement related info.
      """,
-    'author': 'Rooms For (Hong Kong) T/A OSCG',
+    'author': 'Quartile Limited',
     'license': 'LGPL-3',
     'depends': [
         'purchase',
@@ -26,5 +26,4 @@ Main Features
         'wizard/product_procurement_view.xml',
     ],
     'installable': True,
-    'active': False,
 }

--- a/product_procurement_plan/models/__init__.py
+++ b/product_procurement_plan/models/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Rooms For (Hong Kong) Limited T/A OSCG
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from . import stock_config_settings
 from . import res_company

--- a/product_procurement_plan/models/product_product.py
+++ b/product_procurement_plan/models/product_product.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Rooms For (Hong Kong) Limited T/A OSCG
+# Copyright 2017-2018 Quartile Limited
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from odoo import models, fields, api

--- a/product_procurement_plan/models/res_company.py
+++ b/product_procurement_plan/models/res_company.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Rooms For (Hong Kong) Limited T/A OSCG
+# Copyright 2017-2018 Quartile Limited
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from odoo import models, fields

--- a/product_procurement_plan/models/stock_config_settings.py
+++ b/product_procurement_plan/models/stock_config_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Rooms For (Hong Kong) Limited T/A OSCG
+# Copyright 2017-2018 Quartile Limited
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from odoo import models, fields

--- a/product_procurement_plan/wizard/__init__.py
+++ b/product_procurement_plan/wizard/__init__.py
@@ -1,5 +1,3 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Rooms For (Hong Kong) Limited T/A OSCG
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from . import product_procurement

--- a/product_procurement_plan/wizard/product_procurement.py
+++ b/product_procurement_plan/wizard/product_procurement.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Rooms For (Hong Kong) Limited T/A OSCG
+# Copyright 2017-2018 Quartile Limited
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from datetime import datetime

--- a/product_procurement_plan/wizard/product_procurement.py
+++ b/product_procurement_plan/wizard/product_procurement.py
@@ -315,11 +315,11 @@ class ProductProcInfoCompute(models.TransientModel):
     def _get_sorted_parent_products(self):
         products = self._get_products()
         bom_products = self._get_bom_products(products)
-        # loop parent_products and check if the product has a bom record in
-        # which it is a child.
-        # in case the product is a child,
-        # it can be appended to sorted_list
-        # only when the parent product is already in the list
+        # loop through bom_products and check if the product has a bom record
+        # in which it is a child.
+        # in case the product is a child, it can be appended to
+        # sorted_parent_products only when the parent product is already in
+        # the list.
         sorted_parent_products = []
         for prod in bom_products:
             bom_lines = self.env['mrp.bom.line'].search(
@@ -335,12 +335,14 @@ class ProductProcInfoCompute(models.TransientModel):
                             if p in sorted_parent_products:
                                 ok_flag = True
                                 break
+                            elif p not in bom_products:
+                                bom_products.append(p)
                     else:
                         ok_flag = True
-                # if the parent of the product is in sorted_list, the
-                # product should be appended to sorted_list
+                # if the parent of the product is in sorted_parent_products,
+                # the product should be appended to sorted_parent_products
                 # otherwise, the product should be put to the end of
-                # parent_products for next try
+                # bom_products for next try.
                 if ok_flag == True:
                     sorted_parent_products.append(prod)
                 else:

--- a/product_procurement_plan/wizard/product_procurement.py
+++ b/product_procurement_plan/wizard/product_procurement.py
@@ -292,8 +292,7 @@ class ProductProcInfoCompute(models.TransientModel):
         # create a list of bom parent products that are directly related to
         # selected products
         bom_products = []
-        bom_obj = self.env['mrp.bom']
-        bom_recs = bom_obj.search([('active', '=', True)])
+        bom_recs = self.env['mrp.bom'].search([('active', '=', True)])
         for rec in bom_recs:
             if rec.product_id and rec.product_id in products and \
                             rec.product_id not in bom_products:


### PR DESCRIPTION
When a parent product of a selected product is not included in the in the original scope of selected products (active_ids), `_get_sorted_parent_products` method would go into infinite loop.  This PR fixes the issue.