### PR TITLE
[FIX] Conditions in the filtered()

### DIFF
--- a/stock_serial_number/__manifest__.py
+++ b/stock_serial_number/__manifest__.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Quartile Limited
+# Copyright 2017-2018 Quartile Limited
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 {
     'name': 'Stock Serial Number',
-    'version': '10.0.1.1.0',
+    'version': '10.0.1.2.0',
     'author': 'Quartile Limited',
-    'website': 'https://www.odoo-asia.com',
+    'website': 'https://www.quartile.co',
     'category': 'Stock',
     'license': "LGPL-3",
     'description': "",

--- a/stock_serial_number/models/sale_order.py
+++ b/stock_serial_number/models/sale_order.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Quartile Limited
+# Copyright 2017-2018 Quartile Limited
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from odoo import models, fields, api, _
@@ -16,7 +16,7 @@ class SaleOrder(models.Model):
             if order.order_line:
                 lot_ids = []
                 for l in order.order_line.filtered(
-                        lambda l: l.lot_id != False and
+                        lambda l: l.lot_id and
                                         l.product_id.tracking == 'serial'):
                     if l.product_uom_qty > 1.0:
                         raise UserError(_('Quantity of SO line should be 1 '


### PR DESCRIPTION
- When `Many2one` field is not set, accessing the field will return an empty record, e.g. stock.production.lot(), which is not equal `False`