### PR TITLE
[FIX] Use partner_ids instead of sales_data to update pricelist

### DIFF
--- a/sale_pricelist_auto_update/models/res_partner.py
+++ b/sale_pricelist_auto_update/models/res_partner.py
@@ -145,5 +145,6 @@ class ResPartner(models.Model):
             if partner:
                 partner._update_partner_purchase_data(
                     sales_dict['amount'], date_start, date_end)
-                partner._update_current_pricelist()
+        for partner in partner_ids:
+            partner._update_current_pricelist()
         return True


### PR DESCRIPTION
- Case to fix: When the partner does not have sales record last year, the `_update_current_pricelist()` will not be performing.