### PR TITLE
[ADD] Sequence of components menu

### DIFF
--- a/mrp_bom_component_menu/views/mrp_bom_component_view.xml
+++ b/mrp_bom_component_menu/views/mrp_bom_component_view.xml
@@ -26,7 +26,6 @@
         action="mrp_bom_form_action2"
         id="menu_mrp_bom_form_action2"
         parent="mrp.menu_mrp_bom"
-        sequence="98"
-        />
+        sequence="98"/>
 
 </odoo>

--- a/mrp_bom_component_menu/views/mrp_bom_component_view.xml
+++ b/mrp_bom_component_menu/views/mrp_bom_component_view.xml
@@ -25,6 +25,8 @@
     <menuitem
         action="mrp_bom_form_action2"
         id="menu_mrp_bom_form_action2"
-        parent="mrp.menu_mrp_bom"/>
+        parent="mrp.menu_mrp_bom"
+        sequence="98"
+        />
 
 </odoo>


### PR DESCRIPTION
## Description

Adding a sequence of components menu to OCA module.
Because the menu added by OCA module is not aligned with the Bill of Materials menu.

* This problem happens only when the work orders option of Manufacture are enabled.
* The sequence has added in OCA module version 12.0 later. 

### Before 

![image](https://user-images.githubusercontent.com/45782518/63237799-6785ca80-c27e-11e9-8238-394a2507ad82.png)

### After

![image](https://user-images.githubusercontent.com/45782518/63237521-5e482e00-c27d-11e9-83db-3274581c2c8e.png)


## OCA repository

Repo：[manufacture/mrp_bom_component_menu](https://github.com/OCA/manufacture/tree/10.0/mrp_bom_component_menu)
branch：10.0

## Module

pci-custom/mrp_bom_component_menu