### PR TITLE
#481 Allow Inventory / users to see report menu.

### DIFF
--- a/stock_view_adj/__manifest__.py
+++ b/stock_view_adj/__manifest__.py
@@ -3,7 +3,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 {
     'name': 'Stock View Adjust',
-    'version': '10.0.1.1.0',
+    'version': '10.0.1.2.0',
     'author': 'Quartile Limited',
     'website': 'https://www.quartile.co',
     'category': 'Stock',

--- a/stock_view_adj/__manifest__.py
+++ b/stock_view_adj/__manifest__.py
@@ -9,6 +9,7 @@
     'category': 'Stock',
     'license': "LGPL-3",
     'description': """
+- Stock Inventory Security : Allow Inventory/User to see the Inventory/Report menu (Remove Access Rights from Inventory/Reports menu)
 - Stock Inventory View : Display the validation button when operated by Manager and Users.
 - Stock Picking View : Disable Force Availability.
     """,
@@ -16,6 +17,7 @@
         'stock',
     ],
     'data': [
+        'security/stock_inventory_security.xml',
         'views/stock_inventory_views.xml',
         'views/stock_picking_views.xml',
     ],

--- a/stock_view_adj/__manifest__.py
+++ b/stock_view_adj/__manifest__.py
@@ -17,7 +17,6 @@
         'stock',
     ],
     'data': [
-        'security/stock_inventory_security.xml',
         'views/stock_inventory_views.xml',
         'views/stock_picking_views.xml',
     ],

--- a/stock_view_adj/security/stock_inventory_security.xml
+++ b/stock_view_adj/security/stock_inventory_security.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Allow Inventory/User to see the Inventory/Report menu. -->
+    <record model="ir.ui.menu" id="stock.menu_warehouse_report">
+        <field name="groups_id" eval="[(5, 0, 0)]"/> 
+    </record>
+</odoo>

--- a/stock_view_adj/security/stock_inventory_security.xml
+++ b/stock_view_adj/security/stock_inventory_security.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-    <!-- Allow Inventory/User to see the Inventory/Report menu. -->
-    <record model="ir.ui.menu" id="stock.menu_warehouse_report">
-        <field name="groups_id" eval="[(5, 0, 0)]"/> 
-    </record>
-</odoo>

--- a/stock_view_adj/views/stock_inventory_views.xml
+++ b/stock_view_adj/views/stock_inventory_views.xml
@@ -13,4 +13,9 @@
         </field>
     </record>
 
+    <!-- Allow Inventory/User to see the Inventory/Report menu. -->
+    <record model="ir.ui.menu" id="stock.menu_warehouse_report">
+        <field name="groups_id" eval="[(5, 0, 0)]"/> 
+    </record>
+
 </odoo>


### PR DESCRIPTION
## Summary

* **Remove Access Rights from Inventory/Reports menu to allow Inventory/User to see the Inventory/Report menu.**
* **Target menu `Inventory/Reports`**
    * Settings > Technical > User Interface > Menu Items
    * Seaech `report` > Select `99 Inventory/Reports` > ACCESS RIGHTS
        * Before: Inventory / Manager
        * **After: None**
* You can see Odoo documentation about special "commands". https://www.odoo.com/documentation/12.0/reference/orm.html#model-reference

![image](https://user-images.githubusercontent.com/45782518/64137933-b1051680-ce35-11e9-8b39-63a256d3cc80.png)




## Module

pci-custom/stock_view_adj