### PR TITLE
[10.0][ADD][T586] -  Fix issue for upgrade module - product_configurator

### DIFF
--- a/product_configurator/__manifest__.py
+++ b/product_configurator/__manifest__.py
@@ -11,6 +11,7 @@
     "data": [
         'data/menu_configurable_product.xml',
         'data/product_attribute.xml',
+        'data/product_config_step.xml',
         'security/configurator_security.xml',
         'security/ir.model.access.csv',
         'views/assets.xml',

--- a/product_configurator/data/product_config_step.xml
+++ b/product_configurator/data/product_config_step.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="product_configurator.config_step_1"
+                model="product.config.step">
+            <field name="name">Body Color</field>
+        </record>
+        <record id="product_configurator.config_step_3"
+                model="product.config.step">
+            <field name="name">Body Wood &amp; Aging</field>
+        </record>
+        <record id="product_configurator.config_step_4"
+                model="product.config.step">
+            <field name="name">Neck</field>
+        </record>
+        <record id="product_configurator.config_step_5"
+                model="product.config.step">
+            <field name="name">Others</field>
+        </record>
+
+    </data>
+</odoo>


### PR DESCRIPTION
 - Added Demo data with noupdate=1
 - TASK #[586](https://www.quartile.co/web#id=586&action=771&model=project.task&view_type=form&menu_id=505)
- https://prnt.sc/s52lz5
- https://prnt.sc/s52mfi
- In the live server, the data is created through demo data which is temporary but when modules going to upgrade. if the demo data no exist then it will go for delete. So I have created demo data with same record id. 
 - Now we can able to upgrade the module.:product_configurator