### PR TITLE
[1021][IMP] Change free_delivery to free_fix_delivery

### DIFF
--- a/website_product_delivery_method/__manifest__.py
+++ b/website_product_delivery_method/__manifest__.py
@@ -10,7 +10,7 @@
     'description': """
 - Add customer groups to res.partner and filter the delivery method based on \
 customer group of the customer.
-- Add free/fixed price delivery setting to product category which limits \
+- Add free/fixed-price delivery setting to product category which limits \
 delivery methods for the e-commerce sales order if the order only consists \
 of products from free/fixed pric delivery product category.
     """,

--- a/website_product_delivery_method/__manifest__.py
+++ b/website_product_delivery_method/__manifest__.py
@@ -1,21 +1,21 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Quartile Limited
+# Copyright 2017-2020 Quartile Limited
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Website Product Delivery Method',
     'summary': 'Website Product Delivery Method',
-    'version': '10.0.1.0.1',
+    'version': '10.0.1.1.0',
     'license': 'AGPL-3',
-    'category':'Sales',
+    'category': 'Sales',
     'description': """
 - Add customer groups to res.partner and filter the delivery method based on \
 customer group of the customer.
-- Add free delivery setting to product category which allows free delivery \
-for the e-commerce sales order if the order only consists of products from \
-free delivery product category
+- Add free/fixed price delivery setting to product category which limits \
+delivery methods for the e-commerce sales order if the order only consists \
+of products from free/fixed pric delivery product category.
     """,
     'author': 'Quartile Limited',
-    'website': 'https://www.odoo-asia.com',
+    'website': 'https://www.quartile.co',
     'depends': [
         'website_sale_delivery',
     ],

--- a/website_product_delivery_method/__manifest__.py
+++ b/website_product_delivery_method/__manifest__.py
@@ -19,7 +19,7 @@ of products from free/fixed pric delivery product category.
     'depends': [
         'website_sale_delivery',
     ],
-    'data':[
+    'data': [
         'data/customer_group_data.xml',
         'security/ir.model.access.csv',
         'views/customer_group_view.xml',

--- a/website_product_delivery_method/data/customer_group_data.xml
+++ b/website_product_delivery_method/data/customer_group_data.xml
@@ -14,4 +14,3 @@
     </record>
 
 </odoo>
-

--- a/website_product_delivery_method/models/product_category.py
+++ b/website_product_delivery_method/models/product_category.py
@@ -8,7 +8,8 @@ from odoo import fields, models
 class ProductCategory(models.Model):
     _inherit = 'product.category'
 
-    free_delivery = fields.Boolean(
-        string="Free Delivery",
+    free_fix_delivery = fields.Boolean(
+        string="Free/Fixed Price Delivery",
         copy=False,
+        oldname="free_delivery",
     )

--- a/website_product_delivery_method/models/product_category.py
+++ b/website_product_delivery_method/models/product_category.py
@@ -9,7 +9,7 @@ class ProductCategory(models.Model):
     _inherit = 'product.category'
 
     free_fix_delivery = fields.Boolean(
-        string="Free/Fixed Price Delivery",
+        string="Free/Fixed-price Delivery",
         copy=False,
         oldname="free_delivery",
     )

--- a/website_product_delivery_method/models/sale_order.py
+++ b/website_product_delivery_method/models/sale_order.py
@@ -2,7 +2,7 @@
 # Copyright 2017-2020 Quartile Limited
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models, fields, api
+from odoo import models
 
 
 class SaleOrder(models.Model):
@@ -18,12 +18,11 @@ class SaleOrder(models.Model):
             # with matching of partner customer group
             if partner_id.customer_group:
                 available_carriers = available_carriers.filtered(
-                    lambda d: (not d.customer_group) or d.customer_group ==
-                                  partner_id.customer_group)
+                    lambda d: (not d.customer_group) or d.customer_group == partner_id.customer_group)
             # if all order lines are belongs from Free/Fixed Price product
             # category, set the cheapest delivery as the delivery method.
-            non_delivery_line = self.order_line.filtered(lambda i : not
-            i.is_delivery)
+            non_delivery_line = self.order_line.filtered(
+                lambda i : not i.is_delivery)
             if all(i.product_id.categ_id.free_fix_delivery for i in
                    non_delivery_line):
                 available_carriers = available_carriers.filtered(

--- a/website_product_delivery_method/models/sale_order.py
+++ b/website_product_delivery_method/models/sale_order.py
@@ -18,11 +18,12 @@ class SaleOrder(models.Model):
             # with matching of partner customer group
             if partner_id.customer_group:
                 available_carriers = available_carriers.filtered(
-                    lambda d: (not d.customer_group) or d.customer_group == partner_id.customer_group)
-            # if all order lines are belongs from Free/Fixed Price product
-            # category, set the cheapest delivery as the delivery method.
+                    lambda d: (not d.customer_group) or d.customer_group ==
+                    partner_id.customer_group)
+            # if all order lines belong to Free/Fixed-price product category,
+            # set the cheapest delivery as the delivery method.
             non_delivery_line = self.order_line.filtered(
-                lambda i : not i.is_delivery)
+                lambda i: not i.is_delivery)
             if all(i.product_id.categ_id.free_fix_delivery for i in
                    non_delivery_line):
                 available_carriers = available_carriers.filtered(

--- a/website_product_delivery_method/models/sale_order.py
+++ b/website_product_delivery_method/models/sale_order.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Quartile Limited
+# Copyright 2017-2020 Quartile Limited
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import models, fields, api
@@ -20,17 +20,16 @@ class SaleOrder(models.Model):
                 available_carriers = available_carriers.filtered(
                     lambda d: (not d.customer_group) or d.customer_group ==
                                   partner_id.customer_group)
-            # if all order lines are belongs from free delivery product
-            # category then return only free delivery methods
+            # if all order lines are belongs from Free/Fixed Price product
+            # category, set the cheapest delivery as the delivery method.
             non_delivery_line = self.order_line.filtered(lambda i : not
             i.is_delivery)
-            if all(i.product_id.categ_id.free_delivery for i in
+            if all(i.product_id.categ_id.free_fix_delivery for i in
                    non_delivery_line):
                 available_carriers = available_carriers.filtered(
-                    lambda i: i.delivery_type == "fixed" and
-                              i.fixed_price  == 0.0)
+                    lambda i: i.delivery_type == "fixed").sorted(
+                        lambda x: x.fixed_price)[0]
             else:
                 available_carriers = available_carriers.filtered(
-                    lambda i: not(i.delivery_type == "fixed" and
-                                  i.fixed_price == 0.0))
+                    lambda i: not(i.delivery_type == "fixed"))
         return available_carriers

--- a/website_product_delivery_method/views/product_category_view.xml
+++ b/website_product_delivery_method/views/product_category_view.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <record id="product_category_form_view_inherit_free_delivery"
+    <record id="product_category_form_view_inherit_free_fix_delivery"
             model="ir.ui.view">
         <field name="model">product.category</field>
         <field name="name">product.category.form.inherit.free.delivery</field>
         <field name="inherit_id" ref="product.product_category_form_view"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='type']" position="after">
-                <field name="free_delivery" />
+                <field name="free_fix_delivery" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Task#[1021](https://www.quartile.co/web?debug=#id=1021&action=771&model=project.task&view_type=form&menu_id=505)

- Change the `free_delivery` field to `free_fix_delivery` field.
- Remove the `i.fixed_price  == 0.0` while filtering available_carriers.
- Return the cheapest delivery method if multiple available_carriers are available when the order only consists of products from free/fixed pric delivery product category.

Expected Setup:
1. For existing "Free Delivery" delivery method, we can add specific countries to it.
2. Create a new "International Delivery" delivery method with also fixed price but leave the countries empty.

Logic Flow:
1. When oversea customers checkout, only "International Delivery" will be available as "Free Delivery" will be filtered away by Odoo standard logic.
2. When local customers checkout, both "Free Delivery" and "International Delivery" will be available but we only return the cheapest one, i.e. "Free Delivery"