### PR TITLE
st3 [1758][FIX] website_sale_comment_category_wise

### DIFF
--- a/website_sale_comment_category_wise/__manifest__.py
+++ b/website_sale_comment_category_wise/__manifest__.py
@@ -1,19 +1,14 @@
 # -*- coding: utf-8 -*-
-# Copyright 2020 Quartile Limited
+# Copyright 2020-2022 Quartile Limited
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 {
     "name": "Website Sale Comment Category wise",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.1.0",
     "author": "Quartile Limited",
     "website": "https://www.quartile.co",
     "category": "Website",
     "license": "LGPL-3",
-    "depends": [
-        "website_sale",
-    ],
-    "data": [
-        "views/templates.xml",
-        "views/product_public_category_views.xml",
-    ],
+    "depends": ["website_sale"],
+    "data": ["views/templates.xml", "views/product_public_category_views.xml"],
     "installable": True,
 }

--- a/website_sale_comment_category_wise/controllers/main.py
+++ b/website_sale_comment_category_wise/controllers/main.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2020 Quartile Limited
+# Copyright 2020-2022 Quartile Limited
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from odoo import http
@@ -7,9 +7,8 @@ from odoo.http import request
 
 
 class WebsiteSale(http.Controller):
-
     @http.route(["/shop/order/note"], type="json", auth="public", website=True)
     def order_note(self, note, **post):
-        order = request.website.sudo().sale_get_order()
+        order = request.website.sale_get_order()
         if order:
-            order.sudo().note = note
+            order.note = note

--- a/website_sale_comment_category_wise/models/product_public_category.py
+++ b/website_sale_comment_category_wise/models/product_public_category.py
@@ -8,7 +8,4 @@ from odoo import fields, models
 class ProductPublicCategory(models.Model):
     _inherit = "product.public.category"
 
-    website_order_comment = fields.Boolean(
-        string="Website Order Comment",
-        copy=False,
-    )
+    website_order_comment = fields.Boolean(string="Website Order Comment", copy=False)

--- a/website_sale_comment_category_wise/static/src/js/website_payment_note.js
+++ b/website_sale_comment_category_wise/static/src/js/website_payment_note.js
@@ -1,12 +1,14 @@
-odoo.define("website_sale_comment_category_wise.payment", function(require) {
+odoo.define("website_sale_comment_category_wise.payment", function (require) {
     "use strict";
 
     var ajax = require("web.ajax");
     $(document).ready(function () {
-        $("#order_comment").find("[name='note']").on("change", function () {
-            ajax.jsonRpc("/shop/order/note", "call", {
-                'note': $(this).val(),
+        $("#order_comment")
+            .find("[name='note']")
+            .on("change", function () {
+                ajax.jsonRpc("/shop/order/note", "call", {
+                    note: $(this).val(),
+                });
             });
-        });
     });
 });

--- a/website_sale_comment_category_wise/views/templates.xml
+++ b/website_sale_comment_category_wise/views/templates.xml
@@ -13,7 +13,9 @@
             <t t-if="any(record.website_order_comment for record in website_sale_order.website_order_line.mapped('product_id').mapped('public_categ_ids'))">
                 <div class="row form-group" id="order_comment">
                     <label for="note">Comment:</label>
-                    <textarea class="form-control" rows="5" name="note"/>
+                    <textarea class="form-control" rows="5" name="note">
+                        <t t-esc="website_sale_order.note"/>
+                    </textarea>
                 </div>
             </t>
         </xpath>


### PR DESCRIPTION
[1758](https://www.quartile.co/web#id=1758&action=771&active_id=2358&model=project.task&view_type=form&menu_id=505)

Before this commit, everytime note is updated in the payment page,
the partner of the order would switch to the admin user.

We also update the view so that reloading the payment page should
show the existing value from the order for the note field.